### PR TITLE
Add a new BeforeScenario @amqp to setup all queues. This allows to no…

### DIFF
--- a/src/AmqpContext.php
+++ b/src/AmqpContext.php
@@ -65,6 +65,18 @@ class AmqpContext implements Context
     }
 
     /**
+     * @BeforeScenario @amqp
+     *
+     * @Given I setup all amqp queues
+     */
+    public function iSetupAllAmqpQueues(): void
+    {
+        foreach ($this->transports as $queue => $dsn) {
+            $this->getAMQPConnection($queue)->setup();
+        }
+    }
+
+    /**
      * @param string $queueName
      *
      * @Given I clear messages in amqp :queueName queue


### PR DESCRIPTION
… longer have the error message `Could not declare queue. No channel available. (AMQPChannelException)` when the queue doesn't exist yet.